### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+resource_linux
+output_linux


### PR DESCRIPTION
delete my resource_linux and output_linux softlink and set it into ".gitignore".
why I persist to change this, bc I think soft-link is more convient in Linux but 
if push this links to repos, it dirty others code, it is useless for other bc it has
my $HOME name!